### PR TITLE
Expose provider for every order item

### DIFF
--- a/api/management/commands/fixturize.py
+++ b/api/management/commands/fixturize.py
@@ -33,4 +33,5 @@ class Command(BaseCommand):
         extract_group.permissions.add(extract_permission)
         extract_group.save()
         extract_user.groups.add(extract_group)
+        extract_user.identity.company_name = 'ACME'
         extract_user.save()

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -240,8 +240,11 @@ class OrderItemSerializer(serializers.ModelSerializer):
         queryset=Product.objects.all(),
         slug_field='label')
     product_id = serializers.PrimaryKeyRelatedField(read_only=True)
-
+    product_provider = serializers.SerializerMethodField()
     available_formats = serializers.ListField(read_only=True)
+
+    def get_product_provider(self, obj):
+        return obj.product.provider.identity.company_name
 
     class Meta:
         model = OrderItem

--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -153,6 +153,7 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         ordered_item = response.data['items'][0]
         self.assertEqual(ordered_item['product'], data['items'][0]['product'], 'Check product')
+        self.assertEqual(ordered_item['product_provider'], self.config.provider.identity.company_name, 'Check provider is present')
         self.assertEqual(ordered_item['price_status'], OrderItem.PricingStatus.PENDING, 'Check quote is needed')
         self.assertIsNone(response.data['processing_fee'], 'Check quote is needed')
         self.assertIsNone(response.data['total_without_vat'], 'Check quote is needed')


### PR DESCRIPTION
This PR exposes the provider company_name in orderitem. That means that it is possible for the client to see who will do the extraction for every order item in the cart.