### PR TITLE
Switch to a simple column rename instead of drop and create

### DIFF
--- a/api/migrations/0048_remove_order_status_remove_product_status_and_more.py
+++ b/api/migrations/0048_remove_order_status_remove_product_status_and_more.py
@@ -10,22 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
+        migrations.RenameField(
             model_name='order',
-            name='status',
+            old_name='status',
+            new_name='order_status',
         ),
-        migrations.RemoveField(
+        migrations.RenameField(
             model_name='product',
-            name='status',
-        ),
-        migrations.AddField(
-            model_name='order',
-            name='order_status',
-            field=models.CharField(choices=[('DRAFT', 'Draft'), ('PENDING', 'Pending'), ('QUOTE_DONE', 'Quote done'), ('READY', 'Ready'), ('IN_EXTRACT', 'In extract'), ('PARTIALLY_DELIVERED', 'Partially delivered'), ('PROCESSED', 'Processed'), ('ARCHIVED', 'Archived'), ('REJECTED', 'Rejected')], default='DRAFT', max_length=20, verbose_name='order_status'),
-        ),
-        migrations.AddField(
-            model_name='product',
-            name='product_status',
-            field=models.CharField(choices=[('DRAFT', 'Draft'), ('PUBLISHED', 'Published'), ('PUBLISHED_ONLY_IN_GROUP', 'Published only in group'), ('DEPRECATED', 'Deprecated')], default='DRAFT', max_length=30, verbose_name='product_status'),
+            old_name='status',
+            new_name='product_status',
         ),
     ]


### PR DESCRIPTION
The automatic django migration generated a script where it deletes existing column and creates a new one with a default value.

Because we have an existing DB, running migrations will result in turning all existing orders to DRAFT. It's better to just rename the column so we keep data intact.