### PR TITLE
ci: fix auto-merge workflow condition and execute test only on master

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.label.name == 'dependencies' }}
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.issue.labels.*.name, 'dependencies')
     uses: ./.github/workflows/tests.yml
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.label.name == 'dependencies' }}
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.issue.labels.*.name, 'dependencies')
     needs: [tests]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Python unit tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
The condition for the Dependabot auto-merge workflow doesn't work 
Should be working with this PR :crossed_fingers:  (I cannot test this part without committing on master sadly)

I also tweaked the triggering events of the test workflow which will now be triggered on:
- Push **on master branch only** (changed to avoid some duplicated or useless runs) 
- On new pull request
- As a requirement before the dependabot auto-merge workflow