### PR TITLE
Make it possible to customize openlayers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ venv
 
 # customized project files
 settings.py
-api/templates/gis/admin/custom.js
 
 # collected static files
 static/*

--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ python manage.py runserver
 python manage.py test
 ```
 
-## Customize
-
-custom.js in `api/templates/gis/admin`
-
 # OIDC authentication
 
 ## Glossary

--- a/api/admin.py
+++ b/api/admin.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.gis import admin
 from django.http import HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
+from django_extended_ol.forms.widgets import WMTSWidget
 
 from .helpers import send_geoshop_email
 from .models import (
@@ -40,13 +41,9 @@ class CustomModelAdmin(admin.GISModelAdmin):
 
 class CustomGeoModelAdmin(CustomModelAdmin):
     """
-    Custom widget for the admin if a custom js is provided
-    TODO: deprecated in 5.0
+    Custom widget for the admin
     """
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    if Path(f'{current_dir}/templates/gis/admin/custom.js').is_file():
-        map_template = 'gis/admin/custom.html'
-        map_srid = 2056
+    gis_widget = WMTSWidget
 
 
 class DocumentAdmin(CustomModelAdmin):

--- a/api/models.py
+++ b/api/models.py
@@ -482,7 +482,7 @@ class Product(models.Model):
         default=settings.DEFAULT_PRODUCT_THUMBNAIL_URL,
     )
     ts = SearchVectorField(null=True)
-    bbox = settings.SWISS_EXTENT
+    bbox = settings.DEFAULT_EXTENT
     geom = models.MultiPolygonField(
         _("geom"),
         srid=settings.DEFAULT_SRID,

--- a/api/templates/gis/admin/custom.html
+++ b/api/templates/gis/admin/custom.html
@@ -1,2 +1,0 @@
-{% extends "gis/admin/openlayers.html" %}
-{% block openlayers %}{% include "gis/admin/custom.js" %}{% endblock %}

--- a/default_settings.py
+++ b/default_settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'health_check',
     'health_check.db',
     'health_check.contrib.migrations',
+    'django_extended_ol',
 ]
 
 MIDDLEWARE = [
@@ -266,9 +267,8 @@ INTRA_LEGEND_URL = os.environ.get('INTRA_LEGEND_URL', '')
 # FIXME: Does this work with another SRID?
 DEFAULT_SRID = int(os.environ.get('DEFAULT_SRID', '2056'))
 
-# Default Extent
 # default extent is set to the BBOX of switzerland
-SWISS_EXTENT = (2828694.200665463,1075126.8548189853,2484749.5514877755,1299777.3195268118)
+DEFAULT_EXTENT = (2828694.200665463,1075126.8548189853,2484749.5514877755,1299777.3195268118)
 
 # Controls values of metadata accessibility field that will turn the metadata public
 METADATA_PUBLIC_ACCESSIBILITIES = ['PUBLIC', 'APPROVAL_NEEDED']
@@ -349,3 +349,25 @@ if OIDC_ENABLED:
     LOGIN_REDIRECT_URL = os.environ.get("OIDC_REDIRECT_BASE_URL") + "/oidc/callback"
     LOGOUT_REDIRECT_URL = os.environ.get("OIDC_REDIRECT_BASE_URL") + "/"
     LOGIN_URL = os.environ.get("OIDC_REDIRECT_BASE_URL") + "/oidc/authenticate"
+
+# Customize openlayers widget used in admin interface
+OLWIDGET = {
+    "globals": {
+        "srid": DEFAULT_SRID,
+        "extent": [2420000, 130000, 2900000, 1350000],
+        "resolutions": [
+            4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+            1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5
+        ],
+    },
+    "wmts": {
+        "layer_name": 'ch.kantone.cadastralwebmap-farbe',
+        "style": 'default',
+        "matrix_set": '2056',
+        "attributions": '<a target="new" href="https://www.swisstopo.admin.ch/internet/swisstopo/en/home.html"'
+            + '>swisstopo</a>', # optional
+        "url_template": 'https://wmts10.geo.admin.ch/1.0.0/{Layer}/default/current/2056/{TileMatrix}/{TileCol}/{TileRow}.png',
+        "request_encoding": 'REST', # optional
+        "format": 'image/png' # optional
+    }
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,6 +384,20 @@ asgiref = ">=3.6"
 django = ">=3.2"
 
 [[package]]
+name = "django-extended-ol"
+version = "1.0.0"
+description = "An openlayers widget for Django with extended capabilities"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "django_extended_ol-1.0.0-py3-none-any.whl", hash = "sha256:c696802f54c344ecf79531945abf7a569523991eed093c1dec40618625193c0f"},
+    {file = "django_extended_ol-1.0.0.tar.gz", hash = "sha256:588edc02c23b1d5b6dbd121db3512f8e65b301a9a98e5e5b09c04910aa1d6572"},
+]
+
+[package.dependencies]
+Django = ">=5.0"
+
+[[package]]
 name = "django-filter"
 version = "24.3"
 description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
@@ -1083,13 +1097,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "75.1.0"
+version = "75.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-75.1.0-py3-none-any.whl", hash = "sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"},
-    {file = "setuptools-75.1.0.tar.gz", hash = "sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"},
+    {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
+    {file = "setuptools-75.2.0.tar.gz", hash = "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"},
 ]
 
 [package.extras]
@@ -1129,13 +1143,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.1"
+version = "2024.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
-    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]
@@ -1194,4 +1208,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1658b91377739be6d4d98f75238e147d6d81db66c74b01befa032f19c577d602"
+content-hash = "7a880e55b38381e9a1b5d44df751b837b1b45400a999ab47821d1e48846332d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ whitenoise = "^6.7.0"
 Django = "^5.1"
 mozilla-django-oidc = "^4.0.1"
 Authlib = "^1.3.2"
+django-extended-ol = "1.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]


### PR DESCRIPTION
Since the upgrade to Django 5.1, the old way of customizing OpenLayers widget in the admin is not working anymore. This PR makes it work again but in a better way by using a plugin and not by "hacking" the template as it was done before.

For now, it is possible to change the background layer and replace it with a WMTS. By default, swisstopo backend is used:

![image](https://github.com/user-attachments/assets/7a1efc6b-29cc-4b2d-9c64-cc0db915b08e)

all the config is done in the settings.py