### PR TITLE
GSGGR-172 Generate OIDC auth and redirect links in a more Django-like way

### DIFF
--- a/api/templates/admin/login.html
+++ b/api/templates/admin/login.html
@@ -1,5 +1,5 @@
 {% extends "admin/login.html" %}
-{% block body %}
+{% block content %}
     {{ block.super }}
     {% if OIDC_ENABLED %}
     <script>
@@ -7,7 +7,7 @@
           document.querySelector("input[value='Log in']")
               .parentElement
               .parentElement
-              .innerHTML += `<a href="/oidc/authenticate${window.location.search}">Login with Zitadel</a>`;
+              .innerHTML += `<a href="{% url 'oidc_authentication_init' %}?next={{ next }}">Login with Zitadel</a>`;
       };
     </script>
     {% endif %}

--- a/api/templates/rest_framework/login.html
+++ b/api/templates/rest_framework/login.html
@@ -7,7 +7,13 @@
           document.querySelector("input[value='Log in']")
               .parentElement
               .parentElement
-              .innerHTML += `<a href="/oidc/authenticate${window.location.search}">Login with Zitadel</a>`;
+              .innerHTML += `
+              <div class="form-group"></div>
+              <div class="form-actions-no-box">
+                <a href="{% url 'oidc_authentication_init' %}?next={{ next }}">
+                    <input type="button" class="btn btn-primary form-control" value="Login with Zitadel" />
+                </a>
+              </div>`;
       };
     </script>
     {% endif %}


### PR DESCRIPTION
Geoshop backend was always redirecing to "<hostname>/oidc/auth" instead of "<hostname></relative/backend/path>/oidc/auth", but now it works properly