### PR TITLE
Fix multiline "trans" and finish template translations

### DIFF
--- a/api/locale/fr/LC_MESSAGES/django.po
+++ b/api/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-24 17:06+0200\n"
+"POT-Creation-Date: 2024-12-11 12:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,549 +17,549 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: api/admin.py:129
+#: .\api\admin.py:126
 msgid "Invoice contact does not belong to the client of this order!"
 msgstr ""
 "Le contact pour la facturation n'est pas dans le carnet d'adresses du client "
 "à qui appartient cette commande."
 
-#: api/admin.py:175
+#: .\api\admin.py:172
 msgid "All the items have been submitted to Extract again."
 msgstr ""
 "Tous les produits commandés de cette commande ont été renvoyés à Extract."
 
-#: api/admin.py:185
+#: .\api\admin.py:182
 msgid "Quote has been successfully done and an email has been sent to client"
 msgstr "Le devis de la commande a été calculé et le client a été notifié"
 
-#: api/admin.py:189
+#: .\api\admin.py:186
 msgid "Order prices cannot be calculated! Client will not be notified!"
 msgstr ""
 "Le devis de la commande ne peut pas être calculé, le client ne sera pas "
 "notifié"
 
-#: api/admin.py:231
+#: .\api\admin.py:228
 msgid "Permissions"
 msgstr "Permissions"
 
-#: api/admin.py:234
+#: .\api\admin.py:231
 msgid "Important dates"
 msgstr "Dates importantes"
 
-#: api/admin.py:252
+#: .\api\admin.py:249
 msgid "Registration confirmation"
 msgstr "Confirmation d'inscription"
 
-#: api/admin.py:256
+#: .\api\admin.py:253
 msgid "Your account has been registered successfully."
 msgstr "Votre compte est désormais actif."
 
-#: api/admin.py:263
+#: .\api\admin.py:260
 msgid "User is registered and an email has been sent to client"
 msgstr "Le client est actif et un email lui a été envoyé."
 
-#: api/admin.py:267
+#: .\api\admin.py:264
 msgid "User is not active yet! Client will not be notified!"
 msgstr ""
 "Le client n'est pas encore actif, aucun email ne lui a été envoyé pour "
 "l'instant."
 
-#: api/filters.py:20
+#: .\api\filters.py:20
 msgid "Search"
 msgstr "Recherche"
 
-#: api/filters.py:21
+#: .\api\filters.py:21
 msgid "A search term."
 msgstr "Entrez ici votre recherche"
 
-#: api/models.py:31
+#: .\api\models.py:31
 msgid "first_name"
 msgstr "Prénom"
 
-#: api/models.py:32
+#: .\api\models.py:32
 msgid "last_name"
 msgstr "Nom"
 
-#: api/models.py:33
+#: .\api\models.py:33
 msgid "email"
 msgstr "Email"
 
-#: api/models.py:34
+#: .\api\models.py:34
 msgid "street"
 msgstr "adresse"
 
-#: api/models.py:35
+#: .\api\models.py:35
 msgid "street2"
 msgstr "complément d'adresse"
 
-#: api/models.py:36
+#: .\api\models.py:36
 msgid "postcode"
 msgstr "NPA"
 
-#: api/models.py:37
+#: .\api\models.py:37
 msgid "city"
 msgstr "ville"
 
-#: api/models.py:38
+#: .\api\models.py:38
 msgid "country"
 msgstr "pays"
 
-#: api/models.py:39
+#: .\api\models.py:39
 msgid "company_name"
 msgstr "raison sociale"
 
-#: api/models.py:40
+#: .\api\models.py:40
 msgid "phone"
 msgstr "téléphone"
 
-#: api/models.py:58
+#: .\api\models.py:58
 msgid "belongs_to"
 msgstr "appartient à"
 
-#: api/models.py:60 api/models.py:133
+#: .\api\models.py:60 .\api\models.py:133
 msgid "sap_id"
 msgstr "Numéro SAP"
 
-#: api/models.py:61 api/models.py:148
+#: .\api\models.py:61 .\api\models.py:148
 msgid "subscribed"
 msgstr "utilisateur permanent"
 
-#: api/models.py:62
+#: .\api\models.py:62
 msgid "is_active"
 msgstr "actif"
 
-#: api/models.py:66
+#: .\api\models.py:66
 msgid "contact"
 msgstr "contact"
 
-#: api/models.py:74 api/models.py:215
+#: .\api\models.py:74 .\api\models.py:215
 msgid "copyright"
 msgstr "copyright"
 
-#: api/models.py:85 api/models.py:99 api/models.py:110
-#: api/models.py:184 api/models.py:326 api/models.py:394
+#: .\api\models.py:85 .\api\models.py:99 .\api\models.py:110
+#: .\api\models.py:184 .\api\models.py:326 .\api\models.py:394
 msgid "name"
 msgstr "nom"
 
-#: api/models.py:87 api/models.py:625
+#: .\api\models.py:87 .\api\models.py:625
 msgid "link"
 msgstr "lien"
 
-#: api/models.py:87
+#: .\api\models.py:87
 msgid "Please complete the above URL"
 msgstr "Veuillez compléter l'URL ci-dessus"
 
-#: api/models.py:92
+#: .\api\models.py:92
 msgid "document"
 msgstr "document"
 
-#: api/models.py:103 api/models.py:822 api/models.py:1032
+#: .\api\models.py:103 .\api\models.py:822 .\api\models.py:1033
 msgid "data_format"
 msgstr "format du produit"
 
-#: api/models.py:114
+#: .\api\models.py:114
 msgid "order type"
 msgstr "type de commande"
 
-#: api/models.py:115
+#: .\api\models.py:115
 msgid "order types"
 msgstr "types de commande"
 
-#: api/models.py:129
+#: .\api\models.py:129
 msgid "user"
 msgstr "utilisateur"
 
-#: api/models.py:135 api/models.py:1050
+#: .\api\models.py:135 .\api\models.py:1051
 msgid "ide_number"
 msgstr "Numéro IDE"
 
-#: api/models.py:142 api/models.py:1057
+#: .\api\models.py:142 .\api\models.py:1058
 msgid "IDE number is not valid"
 msgstr "Le numéro IDE n'est pas valable"
 
-#: api/models.py:146
+#: .\api\models.py:146
 msgid "contract_accepted"
 msgstr "Date d'acceptation du contrat"
 
-#: api/models.py:147
+#: .\api\models.py:147
 msgid "is_public"
 msgstr "public?"
 
-#: api/models.py:149
+#: .\api\models.py:149
 msgid "birthday"
 msgstr "Date de naissance"
 
-#: api/models.py:153
+#: .\api\models.py:153
 msgid "identity"
 msgstr "identité"
 
-#: api/models.py:161
+#: .\api\models.py:161
 msgid "notation"
 msgstr "notation"
 
-#: api/models.py:162
+#: .\api\models.py:162
 msgid "description_fr"
 msgstr "description"
 
-#: api/models.py:166
+#: .\api\models.py:166
 msgid "metadata_category_ech"
 msgstr "Thématique eCH pour les métadonnées"
 
-#: api/models.py:178
+#: .\api\models.py:178
 msgid "Public"
 msgstr "Public"
 
-#: api/models.py:179
+#: .\api\models.py:179
 msgid "Approval needed"
 msgstr "Diffusion restreinte"
 
-#: api/models.py:180
+#: .\api\models.py:180
 msgid "Not accessible"
 msgstr "Non diffusé"
 
-#: api/models.py:181
+#: .\api\models.py:181
 msgid "Internal"
 msgstr "Non diffusé, métadonnée interne"
 
-#: api/models.py:183
+#: .\api\models.py:183
 msgid "id_name"
 msgstr "nom unique"
 
-#: api/models.py:188
+#: .\api\models.py:188
 msgid "ech_category"
 msgstr "catégorie eCH"
 
-#: api/models.py:192
+#: .\api\models.py:192
 msgid "description_long"
 msgstr "description longue"
 
-#: api/models.py:193
+#: .\api\models.py:193
 msgid "genealogy"
 msgstr "généalogie"
 
-#: api/models.py:195
+#: .\api\models.py:195
 msgid "datasource"
 msgstr "source de diffusion"
 
-#: api/models.py:198
+#: .\api\models.py:198
 msgid "accessibility"
 msgstr "accessibilité"
 
-#: api/models.py:203
+#: .\api\models.py:203
 msgid "scale"
 msgstr "échelle"
 
-#: api/models.py:204
+#: .\api\models.py:204
 msgid "geocat_link"
 msgstr "lien Géocat"
 
-#: api/models.py:205
+#: .\api\models.py:205
 msgid "legend_link"
 msgstr "lien vers la légende"
 
-#: api/models.py:207
+#: .\api\models.py:207
 msgid "image_link"
 msgstr "lien vers l'image"
 
-#: api/models.py:212
+#: .\api\models.py:212
 msgid "wms_link"
 msgstr "lien WMS"
 
-#: api/models.py:213
+#: .\api\models.py:213
 msgid "geoportal_link"
 msgstr "lien géoportail"
 
-#: api/models.py:218
+#: .\api\models.py:218
 msgid "documents"
 msgstr "documents"
 
-#: api/models.py:222 api/templates/metadata.html:57
+#: .\api\models.py:222 .\api\templates\metadata.html:57
 msgid "contact_persons"
 msgstr "Interlocuteurs"
 
-#: api/models.py:230
+#: .\api\models.py:230
 msgid "modified_user"
 msgstr "modifié par"
 
-#: api/models.py:234 api/templates/metadata.html:38
-#: api/templates/metadata_simple.html:23
+#: .\api\models.py:234 .\api\templates\metadata.html:38
+#: .\api\templates\metadata_simple.html:23
 msgid "data_last_update_date"
 msgstr "Dernière mise à jour des données"
 
-#: api/models.py:237 api/templates/metadata.html:48
-#: api/templates/metadata_simple.html:33
+#: .\api\models.py:237 .\api\templates\metadata.html:48
+#: .\api\templates\metadata_simple.html:33
 msgid "update_frequency"
 msgstr "Fréquence de mise à jour"
 
-#: api/models.py:242 api/models.py:287 api/models.py:441
+#: .\api\models.py:242 .\api\models.py:287 .\api\models.py:441
 msgid "metadata"
 msgstr "métadonnée"
 
-#: api/models.py:246
+#: .\api\models.py:246
 msgid "Can view metadata with accessibility set to \"internal\""
 msgstr "Accès aux métadonnées intranet"
 
-#: api/models.py:270 api/templates/metadata.html:97
+#: .\api\models.py:270 .\api\templates\metadata.html:97
 msgid "legend"
 msgstr "Légende"
 
-#: api/models.py:279
+#: .\api\models.py:279
 msgid "image"
 msgstr "image"
 
-#: api/models.py:291
+#: .\api\models.py:291
 msgid "contact_person"
 msgstr "contact"
 
-#: api/models.py:294
+#: .\api\models.py:294
 msgid "role"
 msgstr "role"
 
-#: api/models.py:294
+#: .\api\models.py:294
 msgid "Manager"
-msgstr ""
+msgstr "Gestionnaire"
 
-#: api/models.py:295
+#: .\api\models.py:295
 msgid "is_validator"
 msgstr "Est validateur?"
 
-#: api/models.py:299
+#: .\api\models.py:299
 msgid "metadata_contact"
 msgstr "interlocuteur"
 
-#: api/models.py:316
+#: .\api\models.py:316
 msgid "Free"
 msgstr "gratuit"
 
-#: api/models.py:317
+#: .\api\models.py:317
 msgid "Single"
 msgstr "unique"
 
-#: api/models.py:318
+#: .\api\models.py:318
 msgid "By number of objects"
 msgstr "selon le nombre d'objets"
 
-#: api/models.py:319
+#: .\api\models.py:319
 msgid "By area"
 msgstr "selon la surface"
 
-#: api/models.py:320
+#: .\api\models.py:320
 msgid "From a pricing layer"
 msgstr "selon couche de tarification"
 
-#: api/models.py:322
+#: .\api\models.py:322
 msgid "From children products of this group"
 msgstr "selon les produits enfants de ce groupe"
 
-#: api/models.py:324
+#: .\api\models.py:324
 msgid "Manual"
 msgstr "traitement manuel"
 
-#: api/models.py:328
+#: .\api\models.py:328
 msgid "pricing_type"
 msgstr "type de tarification"
 
-#: api/models.py:331 api/models.py:848
+#: .\api\models.py:331 .\api\models.py:848
 msgid "base_fee"
 msgstr "taxe de base"
 
-#: api/models.py:339
+#: .\api\models.py:339
 msgid "min_price"
 msgstr "prix minimum"
 
-#: api/models.py:347
+#: .\api\models.py:347
 msgid "max_price"
 msgstr "prix maximum"
 
-#: api/models.py:355
+#: .\api\models.py:355
 msgid "unit_price"
 msgstr "prix unitaire"
 
-#: api/models.py:365 api/models.py:404 api/models.py:476
+#: .\api\models.py:365 .\api\models.py:404 .\api\models.py:476
 msgid "pricing"
 msgstr "tarification"
 
-#: api/models.py:396 api/models.py:840
+#: .\api\models.py:396 .\api\models.py:840
 msgid "price"
 msgstr "prix"
 
-#: api/models.py:402 api/models.py:487 api/models.py:573
+#: .\api\models.py:402 .\api\models.py:487 .\api\models.py:573
 msgid "geom"
 msgstr "géométrie"
 
-#: api/models.py:409
+#: .\api\models.py:409
 msgid "pricing_layer"
 msgstr "couche de tarification"
 
-#: api/models.py:431 api/models.py:520
+#: .\api\models.py:431 .\api\models.py:520
 msgid "Draft"
 msgstr "Brouillon"
 
-#: api/models.py:432
+#: .\api\models.py:432
 msgid "Published"
 msgstr "Publié"
 
-#: api/models.py:434
+#: .\api\models.py:434
 msgid "Published only in group"
 msgstr "Seulement dans un groupe"
 
-#: api/models.py:436
+#: .\api\models.py:436
 msgid "Deprecated"
 msgstr "Obsolète"
 
-#: api/models.py:446
+#: .\api\models.py:446
 msgid "label"
 msgstr "étiquette"
 
-#: api/models.py:452
+#: .\api\models.py:452
 msgid "Label contains forbidden characters"
 msgstr "L'étiquette' contient des caractères spéciaux interdits."
 
-#: api/models.py:457
+#: .\api\models.py:457
 msgid "product_status"
 msgstr "Statut"
 
-#: api/models.py:465
+#: .\api\models.py:465
 msgid "group"
 msgstr "groupe"
 
-#: api/models.py:473
+#: .\api\models.py:473
 msgid "provider"
 msgstr "fournisseur"
 
-#: api/models.py:477
+#: .\api\models.py:477
 msgid "free_when_subscribed"
 msgstr "gratuit pour utilisateurs permanents"
 
-#: api/models.py:478
+#: .\api\models.py:478
 msgid "order_index"
 msgstr "rang"
 
-#: api/models.py:480
+#: .\api\models.py:480
 msgid "thumbnail_link"
 msgstr "lien vers l'aperçu"
 
-#: api/models.py:494 api/models.py:819 api/models.py:1016
-#: api/models.py:1028
+#: .\api\models.py:494 .\api\models.py:819 .\api\models.py:1017
+#: .\api\models.py:1029
 msgid "product"
 msgstr "produit"
 
-#: api/models.py:511
+#: .\api\models.py:511
 msgid "thumbnail"
 msgstr "aperçu"
 
-#: api/models.py:521 api/models.py:798 api/models.py:804
+#: .\api\models.py:521 .\api\models.py:798 .\api\models.py:804
 msgid "Pending"
 msgstr "En attente"
 
-#: api/models.py:522
+#: .\api\models.py:522
 msgid "Quote done"
 msgstr "Devis réalisé"
 
-#: api/models.py:523
+#: .\api\models.py:523
 msgid "Ready"
 msgstr "A traiter"
 
-#: api/models.py:524 api/models.py:805
+#: .\api\models.py:524 .\api\models.py:805
 msgid "In extract"
 msgstr "Dans Extract"
 
-#: api/models.py:525
+#: .\api\models.py:525
 msgid "Partially delivered"
 msgstr "Partiellement traité"
 
-#: api/models.py:526 api/models.py:806
+#: .\api\models.py:526 .\api\models.py:806
 msgid "Processed"
 msgstr "Traité"
 
-#: api/models.py:527 api/models.py:807
+#: .\api\models.py:527 .\api\models.py:807
 msgid "Archived"
 msgstr "Archivé"
 
-#: api/models.py:528 api/models.py:808
+#: .\api\models.py:528 .\api\models.py:808
 msgid "Rejected"
 msgstr "Rejeté"
 
-#: api/models.py:531
+#: .\api\models.py:531
 msgid "title"
 msgstr "titre"
 
-#: api/models.py:536
+#: .\api\models.py:536
 msgid "Title contains forbidden characters"
 msgstr "Le titre contient des caractères spéciaux interdits."
 
-#: api/models.py:540
+#: .\api\models.py:540
 msgid "description"
 msgstr "description"
 
-#: api/models.py:542
+#: .\api\models.py:542
 msgid "processing_fee"
 msgstr "taxe de base"
 
-#: api/models.py:550
+#: .\api\models.py:550
 msgid "total_without_vat"
 msgstr "total sans TVA"
 
-#: api/models.py:558
+#: .\api\models.py:558
 msgid "part_vat"
 msgstr "dont TVA"
 
-#: api/models.py:566
+#: .\api\models.py:566
 msgid "total_with_vat"
 msgstr "total avec TVA"
 
-#: api/models.py:575 api/models.py:1048
+#: .\api\models.py:575 .\api\models.py:1049
 msgid "client"
 msgstr "client"
 
-#: api/models.py:580
+#: .\api\models.py:580
 msgid "invoice_contact"
 msgstr "facture"
 
-#: api/models.py:586
+#: .\api\models.py:586
 msgid "invoice_reference"
 msgstr "référence"
 
-#: api/models.py:589
+#: .\api\models.py:589
 msgid "email_deliver"
 msgstr "email de livraison"
 
-#: api/models.py:592
+#: .\api\models.py:592
 msgid "order_type"
 msgstr "type de commande"
 
-#: api/models.py:595
+#: .\api\models.py:595
 #, fuzzy
 #| msgid "price_status"
 msgid "order_status"
 msgstr "statut du prix"
 
-#: api/models.py:600
+#: .\api\models.py:600
 msgid "date_ordered"
 msgstr "date de commande"
 
-#: api/models.py:601
+#: .\api\models.py:601
 msgid "date_downloaded"
 msgstr "date de téléchargement"
 
-#: api/models.py:602
+#: .\api\models.py:602
 msgid "date_processed"
 msgstr "date de traitement"
 
-#: api/models.py:604
+#: .\api\models.py:604 .\api\models.py:860
 msgid "download_guid"
 msgstr "GUID de téléchargement"
 
-#: api/models.py:609 api/models.py:624 api/models.py:814
-#: api/serializers.py:319
+#: .\api\models.py:609 .\api\models.py:624 .\api\models.py:814
+#: .\api\serializers.py:340
 msgid "order"
 msgstr "commande"
 
-#: api/models.py:619
+#: .\api\models.py:619
 msgid "Geoshop - Quote requested"
 msgstr "Geoshop - Devis demandé"
 
-#: api/models.py:622
+#: .\api\models.py:622
 msgid "A new quote has been requested:"
 msgstr ""
 "Un devis a été demandé. Il s'agit soit d'un produit dont la tarification est "
@@ -567,159 +567,164 @@ msgstr ""
 "contact n'est pas encore défini comme tel dans l'admin. Il faut contrôler et "
 "renseigner les prix manuellement dans l'admin du geoshop. Détails:"
 
-#: api/models.py:659
+#: .\api\models.py:659
 msgid "Geoshop - Quote has been done"
 msgstr "Geoshop - Devis réalisé"
 
-#: api/models.py:761
+#: .\api\models.py:761
 msgid "Geoshop - Download ready"
 msgstr "Geoshop - Commande traitée"
 
-#: api/models.py:799
+#: .\api\models.py:799
 msgid "Calculated"
 msgstr "calculé"
 
-#: api/models.py:800
+#: .\api\models.py:800
 msgid "Imported"
 msgstr "importé"
 
-#: api/models.py:803
+#: .\api\models.py:803
 msgid "Validation pending"
 msgstr "En attente de validation"
 
-#: api/models.py:824
+#: .\api\models.py:824
 msgid "srid"
 msgstr "SRID"
 
-#: api/models.py:825
+#: .\api\models.py:825
 msgid "last_download"
 msgstr "date du dernier téléchargement"
 
-#: api/models.py:826
+#: .\api\models.py:826
 msgid "validation_date"
 msgstr "Date de validation"
 
-#: api/models.py:828
+#: .\api\models.py:828
 msgid "price_status"
 msgstr "statut du prix"
 
-#: api/models.py:834
+#: .\api\models.py:834
 msgid "status"
 msgstr "statut"
 
-#: api/models.py:858
+#: .\api\models.py:858
 msgid "comment"
 msgstr "Remarques"
 
-#: api/models.py:859
+#: .\api\models.py:859
 msgid "token"
 msgstr "jeton"
 
-#: api/models.py:863
+#: .\api\models.py:864
 msgid "order_item"
 msgstr "produit commandé"
 
-#: api/models.py:980
+#: .\api\models.py:981
 msgid "Geoshop - Validation requested"
 msgstr "Geoshop - Validation demandée"
 
-#: api/models.py:1007
+#: .\api\models.py:1008
 msgid "db_name"
 msgstr "nom de la bd"
 
-#: api/models.py:1008
+#: .\api\models.py:1009
 msgid "export_name"
 msgstr "nom d'export"
 
-#: api/models.py:1010
+#: .\api\models.py:1011
 msgid "field_type"
 msgstr "type de champ"
 
-#: api/models.py:1013
+#: .\api\models.py:1014
 msgid "field_length"
 msgstr "longueur du champ"
 
-#: api/models.py:1021
+#: .\api\models.py:1022
 msgid "product_field"
 msgstr "attribut"
 
-#: api/models.py:1035
+#: .\api\models.py:1036
 msgid "is_manual"
 msgstr "traitement manuel"
 
-#: api/models.py:1040
+#: .\api\models.py:1041
 msgid "product_format"
 msgstr "Relation format - produit"
 
-#: api/models.py:1064
+#: .\api\models.py:1065
 msgid "user_change"
 msgstr "changement d'un utilisateur"
 
-#: api/pricing.py:34
+#: .\api\pricing.py:34
 msgid "Geoshop - Error, pricing is not defined"
 msgstr "Geoshop - Erreur, tarification inconnue"
 
-#: api/pricing.py:37
+#: .\api\pricing.py:37
 msgid "{} is not defined in pricing module."
 msgstr "{} n'est pas définie dans le module pricing."
 
-#: api/pricing.py:94
+#: .\api\pricing.py:94
 msgid "Geoshop - Error, pricing has no geometries linked to it"
 msgstr "Geoshop - Erreur, la tarification n'a pas de géométrie associée"
 
-#: api/pricing.py:98
+#: .\api\pricing.py:98
 msgid "The pricing \"{}\" is defined but no geometries were found for it."
 msgstr ""
 "La tarification \"{}\" existe mais aucune couche géométrique n'a été trouvée "
 "pour le calcul."
 
-#: api/serializers.py:70
+#: .\api\serializers.py:76
 msgid ""
 "Invalid format: string or unicode input unrecognized as GeoJSON, WKT EWKT or "
 "HEXEWKB."
 msgstr "Format invalide: GeoJSON, WKT EWKT ou HEXEWKB non reconnu."
 
-#: api/serializers.py:75
+#: .\api\serializers.py:81
 msgid "Unable to convert to python object: {}"
 msgstr "Impossible à convertir en objet Python"
 
-#: api/serializers.py:314
+#: .\api\serializers.py:308
+msgid "Order area is too large"
+msgstr "Le périmètre de commande est trop grand"
+
+#: .\api\serializers.py:335
 msgid "Geoshop - Invalid geometry"
 msgstr "Geoshop - Géométrie invalide"
 
-#: api/serializers.py:317
+#: .\api\serializers.py:338
 msgid "A new order has been submitted and its geometry is invalid:"
 msgstr "Une nouvelle commande a été soumise et sa géométrie est invalide:"
 
-#: api/serializers.py:641
+#: .\api\serializers.py:662
 msgid "The two password fields didn't match."
 msgstr "Les deux mots de passe ne correspondent pas"
 
-#: api/templates/admin/api/order_change_form.html:7
+#: .\api\templates\admin\api\order_change_form.html:7
 msgid "Reset order for Extract"
 msgstr "Renvoyer l'entier de la commande à Extract"
 
-#: api/templates/admin/api/order_change_form.html:8
+#: .\api\templates\admin\api\order_change_form.html:8
 msgid "Send quote to client"
 msgstr "Envoyer le devis au client"
 
-#: api/templates/admin/api/user_change_form.html:7
+#: .\api\templates\admin\api\user_change_form.html:7
 msgid "Send confirmation email to client"
 msgstr "Envoyer un email de confirmation au client"
 
-#: api/templates/email_admin.html:4
+#: .\api\templates\email_admin.html:4
 msgid "Dear administrator,"
 msgstr "Hello l'admin du géoshop,"
 
-#: api/templates/email_admin.html:27
-msgid "Cet email vous a été envoyé car vous êtes administrateur du Geoshop."
-msgstr ""
+#: .\api\templates\email_admin.html:27
+msgid ""
+"This email was sent to you because you are an administrator of the Geoshop."
+msgstr "Cet email vous a été envoyé car vous êtes administrateur du Geoshop."
 
-#: api/templates/email_base_template.html:92
+#: .\api\templates\email_base_template.html:92
 msgid "Dear user,"
 msgstr "Bonjour,"
 
-#: api/templates/email_base_template.html:103
+#: .\api\templates\email_base_template.html:103
 msgid ""
 "This is an automated email, please do not reply. For any question, feel free "
 "to contact us at"
@@ -727,25 +732,28 @@ msgstr ""
 "Ceci est un email automatique, prière de ne pas y répondre. Pour toute "
 "question ou information supplémentaire, n'hésitez pas à nous contacter à"
 
-#: api/templates/email_download_ready.html:4
+#: .\api\templates\email_download_ready.html:4
 #, python-format
-msgid " L'extraction pour la commande n°%(order_id)s a été réalisée. "
-msgstr ""
+msgid "The extraction for order n°%(order_id)s has been completed. "
+msgstr "L'extraction pour la commande n°%(order_id)s a été réalisée."
 
-#: api/templates/email_download_ready.html:6
+#: .\api\templates\email_download_ready.html:5
 msgid ""
-" Connectez-vous sur le géoshop et téléchargez les produits commandés dans la "
+"Log in to the Geoshop and download the ordered products from the \"My Orders"
+"\" section\n"
+"or by clicking directly on this link: "
+msgstr ""
+"Connectez-vous sur le géoshop et téléchargez les produits commandés dans la "
 "section \"Mes commandes\"\n"
-"        ou en cliquant directement sur ce lien: "
-msgstr ""
+"ou en cliquant directement sur ce lien: "
 
-#: api/templates/email_download_ready.html:13
-msgid ""
+#: .\api\templates\email_download_ready.html:12
+msgid "Please note that the download links are only available for 1 month."
+msgstr ""
 "Veuillez prendre note que les liens de téléchargement ne sont disponibles "
 "que pendant 1 mois."
-msgstr ""
 
-#: api/templates/email_password_reset.html:4
+#: .\api\templates\email_password_reset.html:4
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
@@ -754,123 +762,154 @@ msgstr ""
 "Vous recevez cet email car vous avez demandé une modification de mot de "
 "passe sur %(site_name)s."
 
-#: api/templates/email_password_reset.html:6
+#: .\api\templates\email_password_reset.html:6
 msgid "Please go to the following page and choose a new password:"
 msgstr "Cliquez sur ce lien pour mettre à jour votre mot de passe:"
 
-#: api/templates/email_password_reset.html:10
+#: .\api\templates\email_password_reset.html:10
 msgid "Your username, in case you’ve forgotten:"
 msgstr "Votre nom d'utilisateur est:"
 
-#: api/templates/email_quote_done.html:4
+#: .\api\templates\email_quote_done.html:4
 #, python-format
-msgid "Le devis pour la commande n°%(order_id)s a été réalisé."
-msgstr ""
+msgid "The quote for order n°%(order_id)s has been completed."
+msgstr "Le devis pour la commande n°%(order_id)s a été réalisé."
 
-#: api/templates/email_quote_done.html:5
+#: .\api\templates\email_quote_done.html:5
 msgid ""
-"Connectez-vous sur le géoshop et confirmez ou annulez votre commande dans la "
-"section \\"
+"Log in to the Geoshop and confirm or cancel your order in the \"My Orders\" "
+"section.\""
 msgstr ""
+"Connectez-vous sur le géoshop et confirmez ou annulez votre commande dans la section"
+" \"Mes commandes\"."
 
-#: api/templates/email_user_change.html:3
+#: .\api\templates\email_user_change.html:3
 msgid ""
+"\n"
+"        <p>Your profile update requests have been sent to the Geoshop "
+"administrators.</p>\n"
+"        <p>\n"
+"          They will be reviewed and implemented in the coming days.  \n"
+"          You will be notified by email once the updates are completed.  \n"
+"        </p>\n"
+msgstr ""
 "\n"
 "        <p>Vos demandes de modification de profil ont été envoyées aux "
 "administrateurs du Geoshop.</p>\n"
 "        <p>\n"
-"          Elles seront analysées et reportées dans les jours à venir.\n"
-"          Vous serez averti par email une fois les modifications "
-"effectuées.\n"
+"          Elles seront analysées et reportées dans les jours à venir.  \n"
+"          Vous serez averti par email une fois les modifications effectuées.  \n"
 "        </p>\n"
-msgstr ""
 
-#: api/templates/email_user_footer.html:4
-msgid "Cet email est adressé à"
-msgstr ""
+#: .\api\templates\email_user_footer.html:4
+msgid "This email was sent to"
+msgstr "Cet email est adressé à"
 
-#: api/templates/email_validation_needed.html:6
+#: .\api\templates\email_validation_needed.html:6
 msgid ""
+"Your approval is required to process an order from the Geoshop. Click on "
+"this link to approve or reject the order:"
+msgstr ""
 "Votre accord est nécessaire en vue de traiter une commande du géoshop. "
 "Cliquez sur ce lien pour valider ou refuser la commande:"
-msgstr ""
 
-#: api/templates/email_welcome_user.html:4
-msgid "Votre demande de création de compte est en cours de vérification."
+#: .\api\templates\email_validation_needed.html:12
+msgid ""
+"Please note that the client will not receive the data until you take action."
 msgstr ""
+"Veuillez noter que le client ne recevra pas les données tant qu'une action de"
+" votre part n'est pas entreprise."
 
-#: api/templates/email_welcome_user.html:5
-msgid "Vous recevrez un email lorsque votre inscription sera validée."
+#: .\api\templates\email_validation_needed.html:13
+msgid "If you believe this email was sent to you in error, please contact "
 msgstr ""
+"Si vous estimez que cet email est une erreur, veuillez s'il vous plaît prendre"
+" contact avec le "
 
-#: api/templates/metadata.html:15 api/templates/metadata_simple.html:10
+#: .\api\templates\email_welcome_user.html:4
+msgid "Your account creation request is under review."
+msgstr "Votre demande de création de compte est en cours de vérification."
+
+#: .\api\templates\email_welcome_user.html:5
+msgid "You will receive an email when your registration is approved."
+msgstr "Vous recevrez un email lorsque votre inscription sera validée."
+
+#: .\api\templates\metadata.html:15 .\api\templates\metadata_simple.html:10
 msgid "metadata_description"
 msgstr "Description du contenu des données"
 
-#: api/templates/metadata.html:28
+#: .\api\templates\metadata.html:28
 msgid "source_scale"
 msgstr "Échelle de la source"
 
-#: api/templates/metadata.html:77
+#: .\api\templates\metadata.html:77
 msgid "external_links"
 msgstr "Liens"
 
-#: api/templates/metadata_base_template.html:13
+#: .\api\templates\metadata_base_template.html:13
 msgid "Metadata"
 msgstr "Métadonnée"
 
-#: api/views.py:212
+#: .\api\views.py:213
 msgid "This orderitem cannot be deleted anymore."
 msgstr "Ce produit ne peut plus être enlevé du panier."
 
-#: api/views.py:232 api/views.py:610
+#: .\api\views.py:233
 msgid "Zip does not exist"
 msgstr "Le fichier zip n'existe pas"
 
-#: api/views.py:297
+#: .\api\views.py:298
 msgid "This order cannot be deleted anymore."
 msgstr "Cette commande ne peut pas être annulée."
 
-#: api/views.py:344
+#: .\api\views.py:345
 msgid "Full zip is not ready"
 msgstr "Le zip contenant l'ensemble des fichiers n'est pas encore prêt."
 
-#: api/views.py:432
+#: .\api\views.py:433
 msgid "Password reset e-mail has been sent."
 msgstr "L'email pour la réinitialisation du mot de passe a été envoyé"
 
-#: api/views.py:459
+#: .\api\views.py:460
 msgid "Password has been reset with the new password."
 msgstr "Votre nouveau mot de passe est sauvegardé"
 
-#: api/views.py:517
+#: .\api\views.py:518
 msgid "Geoshop - New user request"
 msgstr "Geoshop - Nouvel utilisateur à valider"
 
-#: api/views.py:520
+#: .\api\views.py:521
 msgid "A new user account needs to be validated:"
 msgstr "Un nouveau compte utilisateur est en attente de validation."
 
-#: api/views.py:528
+#: .\api\views.py:529
 msgid "Geoshop - New account pending"
 msgstr "Geoshop - Nouveau compte en attente"
 
-#: api/views.py:534 api/views.py:659
+#: .\api\views.py:535 .\api\views.py:673
 msgid "Your data was successfully submitted"
 msgstr "Vos données ont été correctement soumises"
 
-#: api/views.py:643
+#: .\api\views.py:605
+msgid "No object matches given id"
+msgstr "Aucun objet trouvé pour cet id"
+
+#: .\api\views.py:623
+msgid "Zip file not found"
+msgstr "Le fichier zip n'a pas été trouvé"
+
+#: .\api\views.py:657
 msgid "Geoshop - User change request"
 msgstr "Geoshop - Demande de modifications de la part d'un utilisateur"
 
-#: api/views.py:647
+#: .\api\views.py:661
 msgid "The user {} has requested some changes for his user profile."
 msgstr "{} a fait une demande de modification de son profil."
 
-#: api/views.py:653
+#: .\api\views.py:667
 msgid "Geoshop - Your changes request"
 msgstr "Geoshop - Votre demande de modification"
 
-#: api/views.py:676
+#: .\api\views.py:690
 msgid "ok"
 msgstr "ok"

--- a/api/templates/email_admin.html
+++ b/api/templates/email_admin.html
@@ -24,6 +24,6 @@
 {% endblock %}
 {% block footer %}
         <p>
-        {% trans "Cet email vous a été envoyé car vous êtes administrateur du Geoshop." %}
+        {% trans "This email was sent to you because you are an administrator of the Geoshop." %}
         </p>
 {% endblock %}

--- a/api/templates/email_download_ready.html
+++ b/api/templates/email_download_ready.html
@@ -1,16 +1,15 @@
 {% extends "email_base_template.html" %}
 {% load i18n %}
 {% block content %}
-<p>{% blocktrans %} L'extraction pour la commande n°{{ order_id }} a été réalisée. {% endblocktrans %}</p>
-<p>
-        {% blocktrans %} Connectez-vous sur le géoshop et téléchargez les produits commandés dans la section "Mes commandes"
-        ou en cliquant directement sur ce lien: {% endblocktrans %}<br>
-        <a style="color:#26A59A" href="{{ front_url }}/welcome/download/{{ download_guid }}">
-                {{ front_url }}/welcome/download/{{ download_guid }}
-        </a>
+<p>{% blocktrans %}The extraction for order n°{{ order_id }} has been completed. {% endblocktrans %}</p>
+<p>{% blocktrans %}Log in to the Geoshop and download the ordered products from the "My Orders" section
+or by clicking directly on this link: {% endblocktrans %}<br>
+<a style="color:#26A59A" href="{{ front_url }}/welcome/download/{{ download_guid }}">
+{{ front_url }}/welcome/download/{{ download_guid }}
+</a>
 </p>
 <p>
-        {% trans "Veuillez prendre note que les liens de téléchargement ne sont disponibles que pendant 1 mois." %}
+        {% trans "Please note that the download links are only available for 1 month." %}
 </p>
 {% endblock %}
 {% block footer %}

--- a/api/templates/email_quote_done.html
+++ b/api/templates/email_quote_done.html
@@ -1,8 +1,8 @@
 {% extends "email_base_template.html" %}
 {% load i18n %}
 {% block content %}
-        <p>{% blocktrans %}Le devis pour la commande n°{{ order_id }} a été réalisé.{% endblocktrans %}</p>
-        <p>{% trans "Connectez-vous sur le géoshop et confirmez ou annulez votre commande dans la section \"Mes commandes\"." %}</p>
+        <p>{% blocktrans %}The quote for order n°{{ order_id }} has been completed.{% endblocktrans %}</p>
+        <p>{% blocktrans %}Log in to the Geoshop and confirm or cancel your order in the "My Orders" section."{% endblocktrans %}</p>
 {% endblock %}
 {% block footer %}
 {% endblock %}

--- a/api/templates/email_user_change.html
+++ b/api/templates/email_user_change.html
@@ -1,10 +1,10 @@
 {% extends "email_base_template.html" %}
 {% load i18n %}
 {% block content %}{% blocktrans %}
-        <p>Vos demandes de modification de profil ont été envoyées aux administrateurs du Geoshop.</p>
+        <p>Your profile update requests have been sent to the Geoshop administrators.</p>
         <p>
-          Elles seront analysées et reportées dans les jours à venir.
-          Vous serez averti par email une fois les modifications effectuées.
+          They will be reviewed and implemented in the coming days.  
+          You will be notified by email once the updates are completed.  
         </p>
 {% endblocktrans %}{% endblock %}
 {% block footer %}

--- a/api/templates/email_user_footer.html
+++ b/api/templates/email_user_footer.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% block footer %}
         <p>
-          {% trans "Cet email est adressé à" %} {{ first_name }} {{ last_name }}.
+          {% trans "This email was sent to" %} {{ first_name }} {{ last_name }}.
         </p>
 {% endblock %}

--- a/api/templates/email_validation_needed.html
+++ b/api/templates/email_validation_needed.html
@@ -3,14 +3,14 @@
 {% block content %}
 <!-- TODO template needs translation -->
 <p>
-  {% trans "Votre accord est nécessaire en vue de traiter une commande du géoshop. Cliquez sur ce lien pour valider ou refuser la commande:" %}<br>
+  {% trans "Your approval is required to process an order from the Geoshop. Click on this link to approve or reject the order:" %}<br>
   <a style="color:#26A59A" href="{{ front_url }}/welcome/validate/{{ what }}/{{ token }}">
     {{ front_url }}/welcome/validate/{{ what }}/{{ token }}
   </a>
 </p>
 <p>
-    {% trans "Veuillez noter que le client ne recevra pas les données tant qu'une action de votre part n'est pas entreprise.
-    Si vous estimez que cet email est une erreur, veuillez s'il vous plaît prendre contact avec le" %}
+    {% trans "Please note that the client will not receive the data until you take action." %}
+    {% trans "If you believe this email was sent to you in error, please contact " %}
   <a href="mailto:{{ REPLY_TO_EMAIL }}">{{ REPLY_TO_EMAIL }}</a>.
 </p>
 {% endblock %}

--- a/api/templates/email_welcome_user.html
+++ b/api/templates/email_welcome_user.html
@@ -1,8 +1,8 @@
 {% extends "email_base_template.html" %}
 {% load i18n %}
 {% block content %}
-        <p>{% trans "Votre demande de création de compte est en cours de vérification." %}</p>
-        <p>{% trans "Vous recevrez un email lorsque votre inscription sera validée." %}</p>
+        <p>{% trans "Your account creation request is under review." %}</p>
+        <p>{% trans "You will receive an email when your registration is approved." %}</p>
 {% endblock %}
 {% block footer %}
         {% include "email_user_footer.html"%}

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-24 17:06+0200\n"
+"POT-Creation-Date: 2024-12-11 11:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,30 +18,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: default_settings.py:123 settings.py:122
+#: .\default_settings.py:131 .\settings.py:126
 msgid "German"
 msgstr "Allemand"
 
-#: default_settings.py:124 settings.py:123
+#: .\default_settings.py:132 .\settings.py:127
 msgid "Italian"
 msgstr "Italien"
 
-#: default_settings.py:125 settings.py:124
+#: .\default_settings.py:133 .\settings.py:128
 msgid "French"
 msgstr "Français"
 
-#: default_settings.py:126 settings.py:125
+#: .\default_settings.py:134 .\settings.py:129
 msgid "English"
 msgstr "Anglais"
 
-#: default_settings.py:127 settings.py:126
+#: .\default_settings.py:135 .\settings.py:130
 msgid "Romansh"
 msgstr "Romanche"
 
-#: urls.py:18
+#: .\urls.py:32
 msgid "GeoShop Administration"
 msgstr "Administration du GeoShop"
 
-#: urls.py:19
+#: .\urls.py:33
 msgid "GeoShop Admin"
 msgstr "Administration du GeoShop"


### PR DESCRIPTION
This PR:
- Fixes a bug with a multiline `trans` in an email template
- Gets rid of french from email templates