### PR TITLE
feat(GSGGR-403): Allow to define max order area for each product

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -484,6 +484,7 @@ class Product(models.Model):
     )
     ts = SearchVectorField(null=True)
     bbox = settings.DEFAULT_EXTENT
+    max_order_area = models.IntegerField(_("max_order_area"), default=settings.MAX_ORDER_AREA)
     geom = models.MultiPolygonField(
         _("geom"),
         srid=settings.DEFAULT_SRID,


### PR DESCRIPTION
What is different: 

- Env variable MAX_ORDER_AREA is used as a default value for new products / products that don't have max_order_area field
- "max_order_area = 0" for a product means that it doesn't have any order area limits
- "max_order_area" limit is not applied to the request areas that are owned by the user. 
- "unowned_area" (see code) is an part of the request which doesn't belong to any of the Product's owned areas. 
    - If Product's unowned area is less or equal than  Product's max_order_area, then we don't care about it
    - If Product's unowned area is greater than  Product's max_order_area, then (unowned_area.area - max_order_area) ill be added to the overflow error field just for information.
    
Example from a user's perspective: Order affects unowned parts of the product, but extra area is still less than max_order_area, so the order is ok:
![owned_areas](https://github.com/user-attachments/assets/a1438811-eeec-4611-b16a-b763a2fb6371)
![order_with_excluded](https://github.com/user-attachments/assets/ead129a7-1f29-4712-bad5-ef4a0260046a)