### PR TITLE
Add locale claim to the geoshop OIDC request

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -342,7 +342,7 @@ if check_oidc():
     OIDC_PRIVATE_KEYFILE = os.environ.get("OIDC_PRIVATE_KEYFILE")
 
     OIDC_RP_SIGN_ALGO = "RS256"
-    OIDC_RP_SCOPES = "openid profile email address phone"
+    OIDC_RP_SCOPES = "openid profile email address phone locale"
     OIDC_USE_PKCE = True
 
     discovery_info = discover_endpoints(

--- a/oidc.py
+++ b/oidc.py
@@ -32,7 +32,7 @@ def _updateUser(user, claims):
     identity.first_name = claims.get("given_name")
     identity.last_name = claims.get("family_name")
 
-    userLanguage = claims.get("locale", _defaultLanguage).lower()
+    userLanguage = (claims.get("locale") or _defaultLanguage).lower()
     if userLanguage not in _supportedLanguages:
         userLanguage = _defaultLanguage
 


### PR DESCRIPTION
OIDC request needs a special claim to return the user locale and doesn't send it by default: see https://zitadel.com/docs/apis/openidoauth/claims