### PR TITLE
feat(GSGGR-700): Return validation result as json instead of http error

### DIFF
--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -618,8 +618,8 @@ class OrderValidationTests(APITestCase):
                  [2545488, 1203070]]
             ]}
         response = self.client.post(url, self.order_data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
-        errorDetails = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        errorDetails = json.loads(response.content)["error"]
         self.assertEqual(errorDetails['message'], ['Order area is too large'])
         self.assertTrue(errorDetails['expected'][0].startswith('34558655.8'))
         self.assertTrue(errorDetails['actual'][0].startswith('97442812.5'))

--- a/api/views.py
+++ b/api/views.py
@@ -699,8 +699,10 @@ class OrderValidateView(views.APIView):
 
     def post(self, request):
         serializer = OrderSerializer(data=request.data, context={'request': request}, partial=True)
-        serializer.is_valid(raise_exception=True)
-        data = {}
+        data = {
+            "valid": serializer.is_valid(raise_exception=False),
+        }
+        data["error"] = serializer.errors
         if 'excludedGeom' in serializer.validated_data:
             data['excludedGeom'] = serializer.validated_data['excludedGeom'].ewkt
         if 'geom' in serializer.validated_data:


### PR DESCRIPTION
Throwing an error for the validation query makes it a lot more difficult to handle cases where errors are expected. Also, in this case "valid" and "invalid" is a proper response.