### PR TITLE
fix(GSGGR-532): Add a safeguard for the autoincrement counters

### DIFF
--- a/api/management/commands/fixturize.py
+++ b/api/management/commands/fixturize.py
@@ -1,4 +1,8 @@
+import io
 import os
+import logging
+from django.db import connection
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
@@ -6,6 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from api.models import Order
 
 UserModel = get_user_model()
+logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """
@@ -14,11 +19,12 @@ class Command(BaseCommand):
     Creates extract user and group
     Creates internal group
     """
-    def handle(self, *args, **options):
+    def configureAdmin(self):
         admin_user = UserModel.objects.get(username=os.environ.get('ADMIN_USERNAME', 'admin'))
         admin_user.set_password(os.environ['ADMIN_PASSWORD'])
         admin_user.save()
 
+    def configureExtract(self):
         content_type = ContentType.objects.get_for_model(Order)
         Group.objects.update_or_create(name='internal')
         extract_permission = Permission.objects.update_or_create(
@@ -26,16 +32,34 @@ class Command(BaseCommand):
             name='Is extract service',
             content_type=content_type)
         extract_permission[0].save()
-        
+
         extract_group = Group.objects.update_or_create(name='extract')
         extract_group[0].permissions.add(extract_permission[0])
         extract_group[0].save()
 
         if not UserModel.objects.filter(username='external_provider').exists():
             extract_user = UserModel.objects.create_user(
-                username='external_provider', 
+                username='external_provider',
                 password=os.environ['EXTRACT_USER_PASSWORD']
             )
             extract_user.groups.add(extract_group[0])
             extract_user.identity.company_name = 'ACME'
             extract_user.save()
+
+    def configureCounters(self):
+        output = io.StringIO()
+        call_command("sqlsequencereset", "api", stdout=output, no_color=True)
+        sql = output.getvalue()
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+
+        output.close()
+
+    def handle(self, *args, **options):
+        logger.info("Configuring admin user")
+        self.configureAdmin()
+        logger.info("Configuring extract user")
+        self.configureExtract()
+        logger.info("Configuring autoincrement counters")
+        self.configureCounters()

--- a/api/management/commands/seed.py
+++ b/api/management/commands/seed.py
@@ -329,6 +329,8 @@ class Command(BaseCommand):
             {"product_status": Product.ProductStatus.DEPRECATED}
         )
 
+        for i in range(30):
+            self.addProduct(mma, f"{i} Placeholder product", {"product_status": Product.ProductStatus.PUBLISHED})
         for order_item in [
             OrderItem.objects.create(order=order1, product=product1),
             OrderItem.objects.create(order=order1, product=product2),


### PR DESCRIPTION
User cannot add or modify new prodcut ownership areas and gets a plain 500 error with the following error message in the logs:
```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "api_productownership_pkey"
DETAIL:  Key (id)=(11) already exists.
```

Such an error occurs when an user adds data to the table with an exact key value, e.g: ```INSERT INTO table (id, …) VALUES (1, …)``` and doesn’t update a counter for an id column after. Because manual db modifications are rare and not expected to be made by user, there is no need to add a trigger and it would be enough to add a check and update during the “fixturize“ step, along with system users configuration (“admin”, “extract”).