### PR TITLE
Set explicit permissions in the api views

### DIFF
--- a/api/management/commands/fixturize.py
+++ b/api/management/commands/fixturize.py
@@ -19,6 +19,10 @@ class Command(BaseCommand):
     Creates extract user and group
     Creates internal group
     """
+
+    def add_arguments(self, parser):
+        parser.add_argument('skip_counter_check')
+
     def configureAdmin(self):
         admin_user = UserModel.objects.get(username=os.environ.get('ADMIN_USERNAME', 'admin'))
         admin_user.set_password(os.environ['ADMIN_PASSWORD'])
@@ -68,22 +72,23 @@ class Command(BaseCommand):
                     name="Free", pricing_type=Pricing.PricingType.FREE)[0],
                 provider=UserModel.objects.get(username='external_provider'),
                 metadata=Metadata.objects.get_or_create(
-                    id_name=username, name=username, modified_user_id=echo_user.id)[0]
+                    id_name=username,
+                    name=username,
+                    modified_user_id=echo_user.id,
+                    accessibility=Metadata.MetadataAccessibility.INTERNAL)[0]
             )
             ProductFormat.objects.create(
                 product=echo_product,
                 data_format=DataFormat.objects.get_or_create(name=f"{username}_format")[0])
 
-
     def configureCounters(self):
         output = io.StringIO()
         call_command("sqlsequencereset", "api", stdout=output, no_color=True)
         sql = output.getvalue()
-
         with connection.cursor() as cursor:
             cursor.execute(sql)
-
         output.close()
+
 
     def handle(self, *args, **options):
         logger.info("Configuring admin user")
@@ -92,5 +97,8 @@ class Command(BaseCommand):
         self.configureExtract()
         logger.info("Configuring system user for echo: echo")
         self.configureEcho()
-        logger.info("Configuring autoincrement counters")
-        self.configureCounters()
+        if "skip_counter_check" in options:
+            logger.info("Skipping counter check")
+        else:
+            logger.info("Configuring autoincrement counters")
+            self.configureCounters()

--- a/api/tests/factories.py
+++ b/api/tests/factories.py
@@ -22,7 +22,7 @@ class BaseObjectsFactory:
 
     def __init__(self, webclient=None):
         # Creates admin account and Extract group with permissions
-        management.call_command('fixturize')
+        management.call_command('fixturize', "skip_counter_check")
         self.user_private = UserModel.objects.create_user(
             username=self.private_username,
             password=self.password

--- a/api/tests/test_metadata.py
+++ b/api/tests/test_metadata.py
@@ -37,4 +37,4 @@ class MetadataTests(APITestCase):
         url = reverse('metadata-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        self.assertEqual(response.data['count'], 2, 'The two metadatas are visible')
+        self.assertEqual(response.data['count'], 3, 'The two metadatas are visible')

--- a/api/views.py
+++ b/api/views.py
@@ -133,7 +133,7 @@ class IdentityViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ['email']
     filter_backends = [filters.SearchFilter]
     serializer_class = MetadataIdentitySerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_queryset(self):
         user = self.request.user

--- a/api/views.py
+++ b/api/views.py
@@ -57,6 +57,7 @@ class CopyrightViewSet(viewsets.ReadOnlyModelViewSet):
     """
     API endpoint that allows Copyright to be viewed.
     """
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     queryset = Copyright.objects.all()
     serializer_class = CopyrightSerializer
 
@@ -107,6 +108,7 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = Document.objects.all()
     serializer_class = DocumentSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class DataFormatViewSet(viewsets.ReadOnlyModelViewSet):
@@ -115,6 +117,7 @@ class DataFormatViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = DataFormat.objects.all()
     serializer_class = DataFormatSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class IdentityViewSet(viewsets.ReadOnlyModelViewSet):
@@ -130,6 +133,7 @@ class IdentityViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ['email']
     filter_backends = [filters.SearchFilter]
     serializer_class = MetadataIdentitySerializer
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
@@ -183,7 +187,7 @@ class MetadataContactViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = MetadataContact.objects.all()
     serializer_class = MetadataContactSerializer
-
+    permission_classes = [permissions.IsAuthenticated]
 
 class MultiSerializerMixin():
     serializers = {
@@ -242,6 +246,7 @@ class OrderTypeViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = OrderType.objects.all()
     serializer_class = OrderTypeSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class OrderViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
@@ -467,6 +472,7 @@ class ProductFormatViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = ProductFormat.objects.all()
     serializer_class = ProductFormatSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class ProductViewSet(MultiSerializerMixin, viewsets.ReadOnlyModelViewSet):
@@ -487,6 +493,7 @@ class ProductViewSet(MultiSerializerMixin, viewsets.ReadOnlyModelViewSet):
         'list': ProductDigestSerializer,
     }
     ts_field = 'ts'
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_queryset(self):
         return self.querysets.get(self.action, self.querysets['default'])
@@ -498,6 +505,7 @@ class PricingViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = Pricing.objects.all()
     serializer_class = PricingSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class RegisterView(generics.CreateAPIView):

--- a/default_settings.py
+++ b/default_settings.py
@@ -215,7 +215,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,


### PR DESCRIPTION
Based on https://github.com/camptocamp/geoshop-back/issues/191. It is ok to expose some metadata, as it has visibility settings. 