### PR TITLE
feat(GSGGR-673): Allow patch request for contacts

### DIFF
--- a/api/tests/test_user_contact.py
+++ b/api/tests/test_user_contact.py
@@ -88,5 +88,12 @@ class UserContacts(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         url = response.data['results'][0]['url']
 
-        response = self.client.patch(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, 'PATCH not allowed')
+        new_data = {
+            'first_name': "New first name",
+            'last_name': "New last name"
+        }
+        response = self.client.patch(url, new_data, format='json')
+        self.assertTrue(not data.items() <= response.data.items(), 'Check contact is returned on patch')
+
+        fromdb = self.client.get(url, format='json')
+        self.assertTrue(new_data.items() <= fromdb.data.items(), 'Check contact is updated')

--- a/api/views.py
+++ b/api/views.py
@@ -63,6 +63,7 @@ class CopyrightViewSet(viewsets.ReadOnlyModelViewSet):
 class ContactViewSet(mixins.CreateModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.DestroyModelMixin,
+                     mixins.UpdateModelMixin,
                      mixins.ListModelMixin,
                      viewsets.GenericViewSet):
     """


### PR DESCRIPTION
Allow updating billing contacts.

Updating billing information was disabled for an unknown reason. I assume it was done to prevent updating financial information for the existing orders (but in that case deletion should have been disabled too).

@maltaesousa please comment: I can hide this feature behind a flag if needed.