### PR TITLE
fix(GSGGR-694): Update default background color to brown

### DIFF
--- a/api/templates/email_base_template.html
+++ b/api/templates/email_base_template.html
@@ -59,7 +59,7 @@
     }
 
     .header {
-      background: #26a59a;
+      background: #8F472A;
       color: #fff;
       font-weight: bold;
     }


### PR DESCRIPTION
Updated the default color. Now all emails have brown headers instead of teal
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8ac9a0bc-e6d2-4325-a66e-86df9d0bc69f" />
