### PR TITLE
feat(GSGGR-717): Use 'extract' as a default provider for the demo products

### DIFF
--- a/api/management/commands/seed.py
+++ b/api/management/commands/seed.py
@@ -319,20 +319,26 @@ class Command(BaseCommand):
 
         # Products
         product1 = self.addProduct(mma, "MO - Cadastre complet",
-                                   {"product_status": Product.ProductStatus.PUBLISHED})
+                                   {
+                                       "product_status": Product.ProductStatus.PUBLISHED,
+                                       "provider": extractUser,
+                                })
         self.getOrCreate(ProductFormat, product=product1, data_format=data_format)
 
         product2 = self.addProduct(mma, "Maquette 3D", {
             "product_status": Product.ProductStatus.PUBLISHED,
             "pricing": self.getOrCreate(
-                Pricing, name="Paid", defaults={"pricing_type": Pricing.PricingType.SINGLE}
-             )
+                Pricing, name="Paid", defaults={"pricing_type": Pricing.PricingType.SINGLE
+            }),
+            "provider": extractUser,
         })
         self.getOrCreate(ProductFormat, product=product2, data_format=data_format_maquette)
         product_deprecated = self.addProduct(
             mma, "MO07 - Objets divers et éléments linéaires - linéaires",
-            {"product_status": Product.ProductStatus.DEPRECATED}
-        )
+            defaults = {
+                "product_status": Product.ProductStatus.DEPRECATED,
+                "provider": extractUser,
+            })
 
         for order_item in [
             OrderItem.objects.create(order=order1, product=product1),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       LC_COLLATE: "en_US.utf8"
       LC_CTYPE: "en_US.utf8"
     env_file: .env
-    ports:
-      - 5432:5432
     networks:
       - geoshop
     healthcheck:
@@ -87,8 +85,6 @@ services:
       - ./testdata/openid-wellknown.json:/data/.well-known/openid-configuration:ro
     networks:
       - geoshop
-    ports:
-      - "1234:1234"
     healthcheck:
       test: curl -f http://127.0.0.1:1234/.well-known/openid-configuration || exit 1,
       interval: 10s


### PR DESCRIPTION
Now the demo products could be picked up by extract from the beginning, because extract can see only products where the provider is extract's user.