### PR TITLE
GSGGR-721 Call set_price method for newly created order items in the use_largest_area_validation logic

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -758,6 +758,7 @@ class Order(models.Model):
         return price_is_set
 
     def _create_order_item(self, product: Product, data_format: DataFormat):
+        LOGGER.info("Creating OrderItem for Product %s", product.label)
         new_order_item: OrderItem = OrderItem(
             order=self, product=product, data_format=data_format
         )
@@ -784,6 +785,7 @@ class Order(models.Model):
         for child_product in group_of_products.products.all():
             # if child_product is a group, recurse
             if child_product.products.exists():
+                LOGGER.info("Child product %s is a group, expanding product group", child_product)
                 self._flatten_groups(child_product, data_format)
                 continue
 
@@ -801,11 +803,15 @@ class Order(models.Model):
         items = self.items.all()
         for item in items:
             if item.product.use_largest_area_validation:
+                LOGGER.info("Skipping order item with product %s because use_largest_area_validation is TRUE", item.product)
                 continue
             # if the ordered product is a group (i.e., if the product has children)
             if item.product.products.exists():
+                LOGGER.info("Ordered product %s is a group, expanding product group", item.product)
                 self._flatten_groups(item.product, item.data_format)
                 item.delete()
+            else:
+                LOGGER.info("Ordered product %s is not a group", item.product)
 
     def _find_product_with_largest_overlap_recursively(self, product_group: Product) -> Product | None:
         """
@@ -819,6 +825,10 @@ class Order(models.Model):
         candidate_overlap: float | None = None
         child_products: List[Product] = list(
             product_group.products.prefetch_related("products").all()
+        )
+        LOGGER.info(
+            "Group product %s has %s child products, finding child with largest overlap recursively"
+            , product_group, len(child_products)
         )
         for child_product in child_products:
             nested_products: List[Product] = list(child_product.products.all())
@@ -849,10 +859,15 @@ class Order(models.Model):
                 continue
             nested_products: List[Product] = list(order_item.product.products.all())
             if not nested_products:
+                LOGGER.info("No nested products found for OrderItem with Product %s", order_item.product.label)
                 continue
             product_with_largest_overlap: Product | None = (
                 self._find_product_with_largest_overlap_recursively(order_item.product))
             if product_with_largest_overlap is None:
+                LOGGER.warning(
+                    "No product with largest overlap found for OrderItem with Product %s",
+                    order_item.product.label
+                )
                 continue
             self._create_order_item(product_with_largest_overlap, order_item.data_format)
             order_item.delete()
@@ -867,16 +882,23 @@ class Order(models.Model):
         has_all_prices_calculated = True
         for item in items:
             if item.price_status == OrderItem.PricingStatus.PENDING:
+                LOGGER.info("OrderItem for Product %s has price_status PENDING", item.product.label)
                 has_all_prices_calculated = has_all_prices_calculated and False
             if (
                 item.product.metadata.accessibility
                 == Metadata.MetadataAccessibility.APPROVAL_NEEDED
             ):
+                LOGGER.info(
+                    "OrderItem for Product %s has metadata accessibility APPROVAL_NEEDED, initializing validation",
+                    item.product.label
+                )
                 item.ask_validation()
                 item.save()
         if has_all_prices_calculated:
+            LOGGER.info("All OrderItems have a price, setting order status to READY")
             self.order_status = Order.OrderStatus.READY
         else:
+            LOGGER.warning("Not all OrderItems have a price, setting order status to PENDING")
             self.ask_price()
             self.order_status = Order.OrderStatus.PENDING
 

--- a/api/models.py
+++ b/api/models.py
@@ -757,10 +757,29 @@ class Order(models.Model):
             )
         return price_is_set
 
+    def _create_order_item(self, product: Product, data_format: DataFormat):
+        new_order_item: OrderItem = OrderItem(
+            order=self, product=product, data_format=data_format
+        )
+        # If the data format for the group is not available for the item,
+        # pick the first possible
+        LOGGER.debug(f"The product {product.label} in the order with id {self.id} wants format: {data_format}")
+        if new_order_item.data_format.name not in new_order_item.available_formats:
+            first_available_format: DataFormat = product.product_formats.all().first().data_format
+            new_order_item.data_format = (
+                first_available_format
+            )
+            LOGGER.warning(
+                f"{new_order_item.data_format} is not in the available formats {new_order_item.available_formats},"
+                f" so the first available format is chosen instead: {first_available_format}"
+            )
+        new_order_item.set_price()
+        new_order_item.save()
+
     def _flatten_groups(self, group_of_products: Product, data_format: DataFormat):
         """
         Creates an OrderItem for each child found in an incoming group_of_products.
-        The new OrderItems will inherit chosen data_format for the group if possible.
+        The new OrderItems will inherit the data_format chosen for the group if possible.
         """
         for child_product in group_of_products.products.all():
             # if child_product is a group, recurse
@@ -768,28 +787,14 @@ class Order(models.Model):
                 self._flatten_groups(child_product, data_format)
                 continue
 
-            # only create OrderItem for products that intersect current order geom
+            # only create an OrderItem for products that intersect the current order geom
             if child_product.geom.intersects(self.geom):
-                new_item = OrderItem(
-                    order=self, product=child_product, data_format=data_format
-                )
-                # If the data format for the group is not available for the item,
-                # pick the first possible
-                LOGGER.debug(f"{child_product.label} wants format: {data_format}")
-                if new_item.data_format.name not in new_item.available_formats:
-                    LOGGER.warning(
-                        f"{new_item.data_format} is not in {new_item.available_formats}"
-                    )
-                    new_item.data_format = (
-                        child_product.product_formats.all().first().data_format
-                    )
-                new_item.set_price()
-                new_item.save()
+                self._create_order_item(child_product, data_format)
 
     def _expand_product_groups(self):
         """
         When an OrderItem is a group of products and the respective product's flag
-        `use_largest_area_validation` is True, the OrderItem is deleted from the cart and
+        `use_largest_area_validation` is False, the OrderItem is deleted from the cart and
         is replaced with one OrderItem for each product inside the group by calling
         _flatten_groups.
         """
@@ -797,7 +802,7 @@ class Order(models.Model):
         for item in items:
             if item.product.use_largest_area_validation:
                 continue
-            # if ordered product is a group (if product has children)
+            # if the ordered product is a group (i.e., if the product has children)
             if item.product.products.exists():
                 self._flatten_groups(item.product, item.data_format)
                 item.delete()
@@ -849,10 +854,7 @@ class Order(models.Model):
                 self._find_product_with_largest_overlap_recursively(order_item.product))
             if product_with_largest_overlap is None:
                 continue
-            new_order_item: OrderItem = OrderItem(
-                order=self, product=product_with_largest_overlap
-            )
-            new_order_item.save()
+            self._create_order_item(product_with_largest_overlap, order_item.data_format)
             order_item.delete()
 
     def confirm(self):

--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -447,11 +447,10 @@ class OrderTests(APITestCase):
         order = Order.objects.get(pk=order_id)
         item = order.items.filter(token=item.token).first()
         self.assertEqual(OrderItem.OrderItemStatus.PENDING, item.status, 'Item is ready for extraction')
+        self.assertEqual(OrderItem.PricingStatus.CALCULATED, item.price_status, 'Validation item price is calculated')
         self.assertEqual("Validation reason", item.validation_reason, 'Validation reason is set')
         self.assertTrue("approved" in mail.outbox[2].subject)
         self.assertEqual(len(mail.outbox), 3, '123123')
-        for i in order.items.all():
-            self.assertEqual(i.price_status, OrderItem.PricingStatus.CALCULATED)
 
     def test_order_item_validation(self):
         """

--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -450,7 +450,7 @@ class OrderTests(APITestCase):
         self.assertEqual("Validation reason", item.validation_reason, 'Validation reason is set')
         self.assertTrue("approved" in mail.outbox[2].subject)
         self.assertEqual(len(mail.outbox), 3, '123123')
-        for i in items:
+        for i in order.items.all():
             self.assertEqual(i.price_status, OrderItem.PricingStatus.CALCULATED)
 
     def test_order_item_validation(self):

--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -450,6 +450,8 @@ class OrderTests(APITestCase):
         self.assertEqual("Validation reason", item.validation_reason, 'Validation reason is set')
         self.assertTrue("approved" in mail.outbox[2].subject)
         self.assertEqual(len(mail.outbox), 3, '123123')
+        for i in items:
+            self.assertEqual(i.price_status, OrderItem.PricingStatus.CALCULATED)
 
     def test_order_item_validation(self):
         """
@@ -655,7 +657,6 @@ class OrderValidationTests(APITestCase):
         self.assertEqual(responseData['excludedGeom'], 'SRID=2056;POLYGON ((2545605 1211390, 2557089 1210921, 2557441 1202601, 2545488 1203070, 2545605 1211390))')
 
     def test_largest_area_validation_for_grouped_products(self):
-        # 1. Set up child products with specific geometries
         geom_a = MultiPolygon(Polygon.from_bbox((0, 0, 10, 10)))
         child_a = Product.objects.create(
             label="Child A",
@@ -663,7 +664,8 @@ class OrderValidationTests(APITestCase):
             metadata=self.config.public_metadata,
             product_status=Product.ProductStatus.PUBLISHED,
             provider=self.config.provider,
-            geom=geom_a
+            geom=geom_a,
+            use_largest_area_validation=True
         )
 
         geom_b = MultiPolygon(Polygon.from_bbox((20, 0, 30, 10)))
@@ -673,10 +675,10 @@ class OrderValidationTests(APITestCase):
             metadata=self.config.public_metadata,
             product_status=Product.ProductStatus.PUBLISHED,
             provider=self.config.provider,
-            geom=geom_b
+            geom=geom_b,
+            use_largest_area_validation=True
         )
 
-        # 2. Set up a parent product group
         parent_group = Product.objects.create(
             label="Parent Group",
             pricing=self.config.pricings['free'],
@@ -695,7 +697,7 @@ class OrderValidationTests(APITestCase):
             ProductFormat(product=child_b, data_format=self.config.formats['dxf']),
         ])
 
-        # 3. Create an order with a geometry that overlaps more with Child B
+        # Create an order with a geometry that overlaps more with Child B
         order_geom = Polygon.from_bbox((8, 0, 28, 10))
 
         url = reverse('order-list')
@@ -707,7 +709,6 @@ class OrderValidationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         order_id = response.data['id']
 
-        # 4. Add the parent group product to the order
         item_data = {
             "items": [{
                 "product": {"label": "Parent Group"},
@@ -718,18 +719,17 @@ class OrderValidationTests(APITestCase):
         response = self.client.patch(url_detail, item_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
-        # 5. Confirm the order to trigger the resolution logic
         url_confirm = reverse('order-confirm', kwargs={'pk': order_id})
         response = self.client.get(url_confirm, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
-        # 6. Verify that the OrderItem for 'Parent Group' was replaced by 'Child B'
         order: Order = Order.objects.get(pk=order_id)
         self.assertEqual(order.items.count(), 1)
-        resolved_item = order.items.first()
+        resolved_item: OrderItem | None = order.items.first()
 
         if resolved_item is None:
             self.fail("Expected OrderItem to be resolved but none found")
 
         self.assertEqual(resolved_item.product.label, "Child B")
         self.assertEqual(resolved_item.product.id, child_b.id)
+        self.assertEqual(resolved_item.price_status, OrderItem.PricingStatus.CALCULATED)

--- a/api/tests/test_order.py
+++ b/api/tests/test_order.py
@@ -690,6 +690,11 @@ class OrderValidationTests(APITestCase):
         child_b.group = parent_group
         child_b.save()
 
+        ProductFormat.objects.bulk_create([
+            ProductFormat(product=child_a, data_format=self.config.formats['dxf']),
+            ProductFormat(product=child_b, data_format=self.config.formats['dxf']),
+        ])
+
         # 3. Create an order with a geometry that overlaps more with Child B
         order_geom = Polygon.from_bbox((8, 0, 28, 10))
 
@@ -710,7 +715,8 @@ class OrderValidationTests(APITestCase):
             }]
         }
         url_detail = reverse('order-detail', kwargs={'pk': order_id})
-        self.client.patch(url_detail, item_data, format='json')
+        response = self.client.patch(url_detail, item_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         # 5. Confirm the order to trigger the resolution logic
         url_confirm = reverse('order-confirm', kwargs={'pk': order_id})


### PR DESCRIPTION
This PR solves the issue reported in [GSGGR-721](https://camptocamp.atlassian.net/browse/GSGGR-721) by
- setting price for the order item created for the product having the largest overlap with the order geometry

Additionally,
- tests were improved and added
- logging statements were added to facilitate debugging

[GSGGR-721]: https://camptocamp.atlassian.net/browse/GSGGR-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ